### PR TITLE
Fix message type handling for autogen client

### DIFF
--- a/orchestrator/autogen_router.py
+++ b/orchestrator/autogen_router.py
@@ -18,6 +18,7 @@ from typing import Dict, Literal
 
 from dotenv import load_dotenv
 from autogen_ext.models.openai import OpenAIChatCompletionClient
+from autogen_core.models import SystemMessage, UserMessage
 
 load_dotenv()
 
@@ -92,8 +93,8 @@ class Orchestrator:
         """
         resp = await self.client.create(
             messages=[
-                {"role": "system", "content": system},
-                {"role": "user", "content": user},
+                SystemMessage(content=system),
+                UserMessage(content=user, source="user"),
             ],
         )
         # OpenAI互換の想定: choices[0].message.content


### PR DESCRIPTION
## Summary
- use `SystemMessage` and `UserMessage` from autogen-core when calling OpenAIChatCompletionClient

## Testing
- `python orchestrator/test_flask_dev.py` *(fails: GEMINI_API_KEY (or GOOGLE_API_KEY) is required)*

------
https://chatgpt.com/codex/tasks/task_e_68c0ed98a3cc83209650f5d1c1cbd4b5