### PR TITLE
Highlight selected agent with distinct colors

### DIFF
--- a/orchestrator/static/app.js
+++ b/orchestrator/static/app.js
@@ -13,7 +13,14 @@
   };
 
   function clearHighlights(){
-    Object.values(agentEls).forEach(el => el.classList.remove("selected"));
+    Object.values(agentEls).forEach(el =>
+      el.classList.remove(
+        "selected",
+        "selected-coder",
+        "selected-analyst",
+        "selected-travel"
+      )
+    );
   }
 
   async function ask(){
@@ -42,7 +49,7 @@
 
       // data.selected: "coder" | "analyst" | "travel" | "none"
       if(data.selected && agentEls[data.selected]){
-        agentEls[data.selected].classList.add("selected");
+        agentEls[data.selected].classList.add("selected", `selected-${data.selected}`);
       } // "none" の場合はハイライトなし
 
       respEl.textContent = data.response || "(no content)";

--- a/orchestrator/static/styles.css
+++ b/orchestrator/static/styles.css
@@ -121,8 +121,21 @@ html,body{
 /* 選択されたエージェントを強調 */
 .agent-card.selected{
   background:var(--highlight);
+}
+
+.agent-card.selected-coder{
   border-color:var(--primary);
   box-shadow:0 0 0 2px rgba(74,168,255,.25), 0 12px 32px rgba(0,0,0,.35);
+}
+
+.agent-card.selected-analyst{
+  border-color:var(--ok);
+  box-shadow:0 0 0 2px rgba(46,204,113,.25), 0 12px 32px rgba(0,0,0,.35);
+}
+
+.agent-card.selected-travel{
+  border-color:var(--warn);
+  box-shadow:0 0 0 2px rgba(255,204,0,.25), 0 12px 32px rgba(0,0,0,.35);
 }
 
 /* 回答 */


### PR DESCRIPTION
## Summary
- Highlight chosen agent card with a unique color per agent for clearer selection feedback
- Clean up previous highlights before showing new selection

## Testing
- `GEMINI_API_KEY=dummy python orchestrator/test_flask_dev.py`

------
https://chatgpt.com/codex/tasks/task_e_68c0f06700ac8320b13033010c19d7a5